### PR TITLE
fix build with latest raw-window-handle version

### DIFF
--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -19,7 +19,7 @@ unsafe impl HasRawWindowHandle for EditorWindowImpl {
         let mut handle = Win32Handle::empty();
         handle.hwnd = self.hwnd as *mut std::ffi::c_void;
         handle.hinstance =
-            unsafe { libloaderapi::GetModuleHandleW(std::ptr::nul()) } as *mut std::ffi::c_void;
+            unsafe { libloaderapi::GetModuleHandleW(std::ptr::null()) } as *mut std::ffi::c_void;
         RawWindowHandle::Windows(handle)
     }
 }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -20,7 +20,7 @@ unsafe impl HasRawWindowHandle for EditorWindowImpl {
         handle.hwnd = self.hwnd as *mut std::ffi::c_void;
         handle.hinstance =
             unsafe { libloaderapi::GetModuleHandleW(std::ptr::null()) } as *mut std::ffi::c_void;
-        RawWindowHandle::Windows(handle)
+        RawWindowHandle::Win32(handle)
     }
 }
 


### PR DESCRIPTION
there was a type for null and raw-window-handle has been updated to have both Win32 and WinRt support.