### PR TITLE
change MacOs handle to AppKit handle to fix compile error

### DIFF
--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -18,7 +18,7 @@ unsafe impl HasRawWindowHandle for EditorWindowImpl {
         let mut handle = AppKitHandle::empty();
         handle.ns_window = self.ns_window as *mut c_void;
         handle.ns_view = self.ns_view as *mut c_void;
-        RawWindowHandle::MacOS(handle)
+        RawWindowHandle::AppKit(handle)
     }
 }
 


### PR DESCRIPTION
With this changes, it should be possible to use `raw-window-handle` 0.4 on MacOS. Before it didn't compile because `RawWindowHandle::MacOS` didn't exist anymore.